### PR TITLE
Add simple dockerfile to package CLI to run on docker

### DIFF
--- a/rly-cli.Dockerfile
+++ b/rly-cli.Dockerfile
@@ -1,0 +1,5 @@
+FROM node:alpine
+
+RUN npm install -g rly-cli@latest
+
+ENTRYPOINT ["rly-cli"]


### PR DESCRIPTION
Exposes an entrypoint of `rly-cli` so you can issue commands directly
via docker run
